### PR TITLE
KompassVersion for CI version override

### DIFF
--- a/.github/workflows/publish_workflow.yml
+++ b/.github/workflows/publish_workflow.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Publish to Maven Central
         run: |
           ./gradlew publishAllPublicationsToMavenCentralRepository \
-            -Pversion=${{ steps.version.outputs.VERSION }} \
+            -PkompassVersion=${{ steps.version.outputs.VERSION }} \
             -PmavenCentralUsername=${{ secrets.MAVEN_CENTRAL_USERNAME }} \
             -PmavenCentralPassword=${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,13 +16,20 @@ plugins {
     id("signing")
 }
 
-// Set version first
+// Set version first.
+// Resolution order (highest priority first):
+//   1. -PkompassVersion=... passed on the Gradle command line (used by CI publish workflow)
+//   2. kompassVersion=... in local.properties (used for local dev / publishToMavenLocal)
+//   3. literal "1.0.0" fallback (should never be hit in practice)
 val localProps = Properties().apply {
     val f = rootProject.file("local.properties")
     if (f.exists()) f.inputStream().use { load(it) }
 }
 
-val kompassVersion = localProps.getProperty("kompassVersion") ?: "1.0.0"
+val kompassVersion: String =
+    (project.findProperty("kompassVersion") as? String)?.takeIf { it.isNotBlank() }
+        ?: localProps.getProperty("kompassVersion")
+        ?: "1.0.0"
 version = kompassVersion
 
 allprojects {


### PR DESCRIPTION
The root build.gradle.kts read kompassVersion only from local.properties (gitignored) and reassigned project.version unconditionally. As a result, every CI publish since 1.0.0 was actually re-publishing as 1.0.0 and being rejected by Maven Central as a duplicate.

Resolution order is now:
  1. -PkompassVersion=... (used by the publish workflow)
  2. local.properties kompassVersion=...
  3. literal '1.0.0' fallback

Workflow updated to pass -PkompassVersion= instead of -Pversion=.