### PR TITLE
fix(build): auto-release Maven Central deployments after publish

### DIFF
--- a/kompass/build.gradle.kts
+++ b/kompass/build.gradle.kts
@@ -155,7 +155,7 @@ mavenPublishing {
         }
     }
 
-    publishToMavenCentral()
+    publishToMavenCentral(automaticRelease = true)
     signAllPublications()
 }
 


### PR DESCRIPTION
## Summary
- `publishToMavenCentral()` with no args only uploads/stages the deployment to Central Portal without releasing it publicly.
- The CI publish workflow reported the "Publish to Maven Central" step as successful, but `1.1.1` never actually appeared on the public Maven Central listing — it was left sitting as a pending deployment on the Central Portal.
- Passing `automaticRelease = true` makes CI release the deployment in the same step, so a green Actions run now means the artifact is really live.

## Test plan
- [ ] Trigger `workflow_dispatch` on the publish workflow with a new version and confirm the artifact shows up on https://central.sonatype.com/artifact/com.tekmoon/kompass without a manual portal step